### PR TITLE
Support for multiple controllers bound to same models

### DIFF
--- a/lib/angular-sails-bind.js
+++ b/lib/angular-sails-bind.js
@@ -14,8 +14,8 @@
 var app = angular.module("ngSailsBind", []);
 
 app.factory('$sailsBind', [
-    '$q', "$rootScope",
-    function ($q, $rootScope) {
+    '$q', "$rootScope", "$timeout", "$log",
+    function ($q, $rootScope, $timeout, $log) {
         'use strict';
         /**
          * This function basically does three things:
@@ -45,13 +45,12 @@ app.factory('$sailsBind', [
             });
 
             //2. Hook the socket events to update the model.
-            io.socket.on(resourceName, function (message) {
+            function onMessage(message) {
                 var elements = $scope[resourceName + "s"],
                     actions = {
                         created: function () {
-                            $scope.$apply(function() {
-                                $scope[resourceName + "s"].push(message.data);
-                            });
+                            $scope[resourceName + "s"].push(message.data);
+                            return true;
                         },
                         updated: function () {
                             var updatedElement = elements.find(
@@ -59,8 +58,11 @@ app.factory('$sailsBind', [
                                     return message.id == element.id;
                                 }
                             );
-
-                            angular.extend(updatedElement, message.data);
+                            if (updatedElement) {
+                                angular.extend(updatedElement, message.data);
+                                return true;
+                            }
+                            return false;
                         },
                         destroyed: function () {
                             var deletedElement = elements.find(
@@ -69,14 +71,23 @@ app.factory('$sailsBind', [
                                 }
                             );
                             if (deletedElement) {
-                                $scope.$apply(function() {
-                                    elements.splice(elements.indexOf(deletedElement), 1);
-                                });
+                                elements.splice(elements.indexOf(deletedElement), 1);
+                                return true;
                             }
+                            return false;
                         }
                     };
-                actions[message.verb]();
-                $scope.$apply();
+                if (actions[message.verb]) {
+                  if (actions[message.verb]())
+                      $timeout(function(){ $scope.$apply(); });
+                } else {
+                  $log.log("Unknown action »"+message.verb+"«");
+                }
+            }
+            io.socket.on(resourceName, onMessage);
+            $scope.$on(resourceName, function (event, message) {
+              if ($scope.$id!=message.scope)
+                  onMessage(message);
             });
 
             //3. Watch the model for changes and send them to the backend using socket.
@@ -91,6 +102,7 @@ app.factory('$sailsBind', [
                     removedElements.forEach(function (item) {
                         _get("/" + resourceName + "?id=" + item.id ).then(function (itemIsOnBackend) {
                             if (itemIsOnBackend && !itemIsOnBackend.error) {
+                                $rootScope.$broadcast(resourceName, { id: item.id, verb: 'destroyed', scope: $scope.$id });
                                 io.socket.delete('/' + resourceName + '/destroy/' + item.id);
                             }
                         });
@@ -101,6 +113,7 @@ app.factory('$sailsBind', [
                             io.socket.put('/' + resourceName + '/create/', item, function (data) {
                                 _get("/" + resourceName + "/" + data.id ).then(function (newData) {
                                     angular.extend(item, newData);
+                                    $rootScope.$broadcast(resourceName, { id: item.id, verb: 'created', scope: $scope.$id, data: angular.copy(item) });
                                 });
                             });
                         }
@@ -131,6 +144,7 @@ app.factory('$sailsBind', [
                             if (!angular.equals(oldValue, newValue) && // is in the database and is not new
                                 oldValue.id == newValue.id && //not a shift
                                 oldValue.updatedAt === newValue.updatedAt) { //is not an update FROM backend
+                                $rootScope.$broadcast(resourceName, { id: oldValue.id, verb: 'updated', scope: scope.$id, data: angular.extend(angular.copy(newValue),{ updatedAt: (new Date()).toISOString() }) });
                                 io.socket.post('/' + resourceName + '/update/' + oldValue.id,
                                     angular.copy(newValue));
                             }


### PR DESCRIPTION
- Added support for using angular-sails-bind with multiple controllers on the same models. Changes in one instances are being broadcasted locally to all other instances. So there is no need to enable io.socket mirroring in sails.
- Changed $apply dealing: calling $apply only if something was changed and always deferred to next event loop cycle in order to avoid calling of $apply when another $apply is already running
