### PR TITLE
Added support for prefix in the route of the model

### DIFF
--- a/lib/angular-sails-bind.js
+++ b/lib/angular-sails-bind.js
@@ -23,23 +23,32 @@ app.factory('$sailsBind', [
          *     resourceName endpoint.
          *  2. Setup the socket's incoming messages (created, updated and destroyed) to update the model.
          *  3. Setup watchers to the model to persist the changes via socket to the backend.
-         * @param resourceName {string} is the name of the resource in the backend to bind.
+         * @param resourceName {string} is the name of the resource in the backend to bind, can have prefix route.
          * @param $scope {object} is the scope where to attach the bounded model.
          * @param subset {json} is the query parameters where you can filter and sort your initial model fill.
          *        check http://beta.sailsjs.org/#!documentation/reference/Blueprints/FindRecords.html to see
          *        what you can send.
          */
         var bind = function (resourceName, $scope, subset) {
+
+            var prefix = resourceName.split('/');
+            if(prefix.length>1) {
+                resourceName = prefix.splice(prefix.length - 1, 1);
+                prefix = prefix.join('/') + '/';
+            }else{
+                prefix = '';
+            }
+
             var defer_bind = new $q.defer();
             //1. Get the initial data into the newly created model.
-            var requestEnded = _get("/" + resourceName, subset);
+            var requestEnded = _get("/" + prefix + resourceName, subset);
 
             requestEnded.then(function (data) {
         		if ( ! Array.isArray(data) ) {
         			data=[data];
         		}
                 $scope[resourceName + "s"] = data;
-                addCollectionWatchersToSubitemsOf(data, $scope, resourceName);
+                addCollectionWatchersToSubitemsOf(data, $scope, resourceName, prefix);
                 init();
                 defer_bind.resolve();
             });
@@ -100,18 +109,18 @@ app.factory('$sailsBind', [
                     removedElements = diff(oldValues, newValues);
 
                     removedElements.forEach(function (item) {
-                        _get("/" + resourceName + "?id=" + item.id ).then(function (itemIsOnBackend) {
+                        _get("/" + prefix + resourceName + "?id=" + item.id ).then(function (itemIsOnBackend) {
                             if (itemIsOnBackend && !itemIsOnBackend.error) {
                                 $rootScope.$broadcast(resourceName, { id: item.id, verb: 'destroyed', scope: $scope.$id });
-                                io.socket.delete('/' + resourceName + '/destroy/' + item.id);
+                                io.socket.delete("/" + prefix + resourceName + '/destroy/' + item.id);
                             }
                         });
                     });
 
                     addedElements.forEach(function (item) {
                         if (!item.id) { //if is a brand new item w/o id from the database
-                            io.socket.put('/' + resourceName + '/create/', item, function (data) {
-                                _get("/" + resourceName + "/" + data.id ).then(function (newData) {
+                            io.socket.put("/" + prefix + resourceName + '/create/', item, function (data) {
+                                _get("/" + prefix + resourceName + "/" + data.id ).then(function (newData) {
                                     angular.extend(item, newData);
                                     $rootScope.$broadcast(resourceName, { id: item.id, verb: 'created', scope: $scope.$id, data: angular.copy(item) });
                                 });
@@ -121,7 +130,7 @@ app.factory('$sailsBind', [
                     });
 
                     // Add Watchers to each added element
-                    addCollectionWatchersToSubitemsOf(addedElements, $scope, resourceName);
+                    addCollectionWatchersToSubitemsOf(addedElements, $scope, resourceName,prefix);
                 });
             };
 
@@ -134,7 +143,7 @@ app.factory('$sailsBind', [
          * @param scope is the scope where the model belongs to
          * @param resourceName is the "singular" version of the model as used by sailsjs
          */
-        var addCollectionWatchersToSubitemsOf = function (model, scope, resourceName) {
+        var addCollectionWatchersToSubitemsOf = function (model, scope, resourceName, prefix) {
             model.forEach(function (item) {
                 scope.$watchCollection(
                         resourceName + 's' + '[' + scope[resourceName + "s"].indexOf(item) + ']',
@@ -145,7 +154,7 @@ app.factory('$sailsBind', [
                                 oldValue.id == newValue.id && //not a shift
                                 oldValue.updatedAt === newValue.updatedAt) { //is not an update FROM backend
                                 $rootScope.$broadcast(resourceName, { id: oldValue.id, verb: 'updated', scope: scope.$id, data: angular.extend(angular.copy(newValue),{ updatedAt: (new Date()).toISOString() }) });
-                                io.socket.post('/' + resourceName + '/update/' + oldValue.id,
+                                io.socket.post("/" + prefix  + resourceName + '/update/' + oldValue.id,
                                     angular.copy(newValue));
                             }
                         }

--- a/test/bindServiceSpec.js
+++ b/test/bindServiceSpec.js
@@ -14,7 +14,7 @@ describe('the angular sailsjs bind service', function () {
             $rootScope = _$rootScope_;
         });
 
-        inject(function($injector) {
+        inject(function ($injector) {
             $timeout = $injector.get('$timeout');
             //$timeout.flush();
         });
@@ -161,14 +161,170 @@ describe('the angular sailsjs bind service', function () {
         });
     });
 
+    describe('the bind function with prefix', function () {
+        var modelName = "myModelItem",
+            defaultData;
+
+        beforeEach(function () {
+            defaultData = [
+                {'id': '1', 'modelAttribute1': "string", 'modelAttribute2': 'another string'},
+                {'id': '2', 'modelAttribute1': "4", 'modelAttribute2': '10'}
+            ];
+
+            //Mock the initial "get all"
+            io.socket.when.get["/api/" + modelName] = {return: defaultData};
+
+            //Do the binding.
+            $sailsBind.bind("api/" + modelName, $rootScope);
+            $timeout.flush();
+        });
+
+        it('should create a model named ' + modelName, function () {
+            expect($rootScope[modelName + 's']).to.be.an("array");
+        });
+        it('should load the model with the contents from the backend', function () {
+            expect(io.socket.requestCalled.url).to.equal("/api/" + modelName);
+
+            expect($rootScope[modelName + 's']).to.deep.equal(defaultData);
+        });
+
+        it('should update the model when a new element is ADDED in the backend', function () {
+            //Simulate an "on-created" event sent from the server for this model
+            io.socket.triggerOn(modelName, 'created', {'id': '3', 'modelAttribute1': "new", 'modelAttribute2': 'data'});
+            $timeout.flush();
+            expect($rootScope[modelName + 's']).to.have.length(3);
+        });
+
+        it('should update the model when an  element is DELETED in the backend', function () {
+            var removedData = {'id': 2};
+
+            //Mock server so it doesn't return item #2 anymore.
+            io.socket.when.get["/api/" + modelName] =
+            { return: {'id': '1', 'modelAttribute1': "string", 'modelAttribute2': 'another string'}
+            };
+
+            //Mock server to find nothing when finding item #2,
+            io.socket.when.get["/api/" + modelName + "?id=" + removedData.id ] = {return: {error: "id not found"}};
+
+            //Simulate an "on-delete" event sent from the server for this model
+            io.socket.triggerOn(modelName, 'destroyed', removedData, removedData.id);
+            $timeout.flush();
+
+            expect($rootScope[modelName + 's']).to.have.length(1);
+        });
+
+        it('should update the model when an is MODIFIED in the backend', function () {
+            var modifiedItem = {'id': '2', 'modelAttribute1': "4", 'modelAttribute2': 'not10'};
+
+            //Simulate someone has modified item 2 in the database.
+            io.socket.triggerOn(modelName, 'updated', modifiedItem, modifiedItem.id);
+            $timeout.flush();
+
+            expect($rootScope[modelName + 's'][1]).to.deep.equal(modifiedItem);
+        });
+
+        it('should persist in the backend when a new element is ADDED in the client', function () {
+            var newElementCreatedInClient = {name: "newElement"},
+                newElementAsReturnedByBackend = {id: 3, name: "newElement"};
+
+            //Mock the server to accept the creation and return the ID of the newly created item.
+            io.socket.when.put["/api/" + modelName + "/create/"] = {return: newElementAsReturnedByBackend};
+
+            //Mock the server to return the new item after it Setup so that the backend
+            //     returns the newly created item with the id.
+            io.socket.when.get["/api/" + modelName + "/" + newElementAsReturnedByBackend.id] = {
+                return: newElementAsReturnedByBackend
+            };
+
+            //Modify the model
+            $rootScope[modelName + 's'].push(newElementCreatedInClient);
+            //$timeout.flush();
+            $rootScope.$apply();
+            $timeout.flush();
+
+            //Check that things were sent to the server as expected
+            expect(io.socket.putCalled.data).to.deep.equal(newElementCreatedInClient);
+            expect(io.socket.putCalled.url).to.equal("/api/" + modelName + "/create/");
+            expect($rootScope[modelName + 's'][2]).to.deep.equal(newElementAsReturnedByBackend);
+        });
+
+        it('should persist in the backend when an element is REMOVED in the client', function () {
+            var removedData = $rootScope[modelName + 's'].pop();
+
+            //Setup backend to simulate the item wasn't removed there yet.
+            io.socket.when.get["/api/" + modelName + "?id=" + removedData.id] = {return: removedData};
+
+            //Setup the socket mock to return the id of the deleted item
+            io.socket.when.delete["/api/" + modelName + "/destroy/" + removedData.id] = {return: removedData};
+
+            //Modify the model (actually "apply" and "flush" the deletion).
+            $rootScope.$apply();
+            $timeout.flush();
+
+            //Check that things were sent to the server as expected
+            expect(io.socket.deleteCalled.url).to.equal("/api/" + modelName + "/destroy/" + removedData.id);
+        });
+
+        it('should persist in the backend when a new element is MODIFIED in the client', function () {
+            var dataToModify = $rootScope[modelName + 's'][1];
+
+            //Setup backend to simulate the item wasn't removed there yet.
+            //io.socket.when.get["/" + modelName + "?id=" + removedData.id] = {return: removedData};
+
+            //Setup the socket mock to return the id of the deleted item
+            //io.socket.when.delete["/" + modelName + "/destroy/" + removedData.id] = {return: removedData};
+
+            //Modify the model (actually "apply" and "flush" the deletion).
+            $rootScope[modelName + 's'][1].modelAttribute1 = "another string";
+            $rootScope.$apply();
+
+            //Check that things were sent to the server as expected
+            expect(io.socket.postCalled.url).to.equal("/api/" + modelName + "/update/" + dataToModify.id);
+            expect(io.socket.postCalled.data).to.deep.equal(dataToModify);
+        });
+
+        it('should  filter the initial model load using the criteria specified in the third argument.', function () {
+            var query = {'modelAttribute1': "4"};
+            //Do the binding.
+            $sailsBind.bind("api/" + modelName, $rootScope, query);
+            $timeout.flush();
+
+            //Check that things were sent to the server as expected
+            expect(io.socket.requestCalled.additional).to.equal(query);
+
+        });
+    });
+
+
+    describe('the bind function with prefix, when the server returns an object instead of an array', function () {
+        var modelName = "myModelItem",
+            defaultData;
+
+        beforeEach(function () {
+            defaultData =
+            {'id': '1', 'modelAttribute1': "string", 'modelAttribute2': 'another string'};
+
+            //Mock the initial "get all"
+            io.socket.when.get["/api/" + modelName] = {return: defaultData};
+
+            //Do the binding.
+            $sailsBind.bind('api/' + modelName, $rootScope);
+            $timeout.flush();
+        });
+
+        it('should still create an array in the scope', function () {
+            expect($rootScope[modelName + 's']).to.be.an("array");
+        });
+    });
+
 
     describe('the bind function, when the server returns an object instead of an array', function () {
         var modelName = "myModelItem",
             defaultData;
 
         beforeEach(function () {
-            defaultData = 
-                {'id': '1', 'modelAttribute1': "string", 'modelAttribute2': 'another string'};
+            defaultData =
+            {'id': '1', 'modelAttribute1': "string", 'modelAttribute2': 'another string'};
 
             //Mock the initial "get all"
             io.socket.when.get["/" + modelName] = {return: defaultData};
@@ -178,8 +334,8 @@ describe('the angular sailsjs bind service', function () {
             $timeout.flush();
         });
 
-	it('should still create an array in the scope', function() {
+        it('should still create an array in the scope', function () {
             expect($rootScope[modelName + 's']).to.be.an("array");
-	});
+        });
     });
 });


### PR DESCRIPTION
Now when a prefix is used in blueprints, we can call sails bind with the prefix in the resourceName. The resourceName can have the prefix string added, and the array created in $scope, will have the name of the endpoint only.

example.
Insted of calling 
   $sailsBind.bind("item", $scope, {"name": {"contains": "Foo"}};

if I configure the prefix in blueprints.js with   " prefix: '/api' ", now I can call sailsBind like

   $sailsBind.bind("api/item", $scope, {"name": {"contains": "Foo"}};

I has copy/pasted the test and changed the resourceName to test this. I dont know if there is a better/cleaner weay.
