### PR TITLE
Added main attribute to describe target file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-sails-bind",
   "version": "1.0.5",
-  "main": "dist/angular-sails-bind.min",
+  "main": "dist/angular-sails-bind.min.js",
   "ignore": [
     "lib",
     "test",


### PR DESCRIPTION
I noticed that when using Wiredep, the injector for grunt, it gave me a message about this dependency not being injected. That is because the bower.json has no 'main' attribute describing the target file. See http://bower.io/docs/creating-packages/.
