### PR TITLE
Define primary acting file of package.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,9 @@
     "package.json",
     "README.md"
   ],
+  "main": [
+    "dist/angular-sails-bind.js"
+  ],
   "dependencies": {
     "angular": "*"
   },


### PR DESCRIPTION
This is necessary to prevent `sails` asset management from unconditionally picking up all the `*.js` files in the package.
